### PR TITLE
editing swimming tracks

### DIFF
--- a/js/trace.js
+++ b/js/trace.js
@@ -1101,12 +1101,12 @@ export default class Trace {
         this.deletePointManual(marker);
 
         if (this.buttons.routing) {
-            if(!marker._prec.equals(marker._pt) && !marker._succ.equals(marker._pt)) this.askRoute2(a, c, marker._layer);
-            else {
+            //if(!marker._prec.equals(marker._pt) && !marker._succ.equals(marker._pt)) this.askRoute2(a, c, marker._layer);
+            //else {
                 this.recomputeStats();
                 this.update();
                 this.redraw();
-            }
+            //}
         }
     }
 


### PR DESCRIPTION
Quick hack to allow edit swimming tracks

This just allows to delete points without look for the nearest point on ground

TODO: Flag to enable edit without recalculate point (detect swimming activity?)
Allow to edit points without recalculate

Fixes #21 