### PR TITLE
Add support for trace width customization

### DIFF
--- a/about.html
+++ b/about.html
@@ -317,15 +317,16 @@
                 <div id="extract" style="display: none">Click on <i class="fas fa-list-ul button"></i> (available only if the file has more than one track segment). If the GPX file contains waypoints (points of interest), they are kept in the files for which the traces pass closest.</div></div>
                 <div class="guide-item"><a name="copy-file" href="#copy-file" class="my-anchor"><div class="guide-title" onclick="toggle('copy')">Copy a GPX file</div></a>
                 <div id="copy" style="display: none">Click on <i class="fas fa-copy button"></i> to duplicate a GPX file.</div></div>
-                <div class="guide-item"><a name="change-color" href="#change-color" class="my-anchor"><div class="guide-title" onclick="toggle('color')">Change the color of a GPX file</div></a>
+                <div class="guide-item"><a name="change-color" href="#change-color" class="my-anchor"><div class="guide-title" onclick="toggle('color')">Change the color, opacity and width of a GPX file</div></a>
                 <div id="color" style="display: none">
                     <ol>
                         <li>Click on <i class="fas fa-palette button"></i>.</li>
                         <li>Click on the color to open the color picker.</li>
-                        <li>Move the slider to change the opacity.</li>
+                        <li>Move the opacity slider to change the opacity.</li>
+                        <li>Move the width slider to change the width.</li>
                         <li>Click on <span class="button">Ok</span>.</li>
                     </ol>
-                    You can optionally apply the chosen color and opacity to all traces by using the checkboxes.
+                    You can optionally apply the chosen color, opacity and width to all traces by using the checkboxes.
                 </div></div>
                 <div class="guide-item"><a name="add-waypoint" href="#add-waypoint" class="my-anchor"><div class="guide-title" onclick="toggle('add-wpt')">Add waypoints (points of interest) to a GPX file</div></a>
                 <div id="add-wpt" style="display: none">

--- a/include/gpx/gpx.js
+++ b/include/gpx/gpx.js
@@ -653,6 +653,13 @@ L.GPX = L.FeatureGroup.extend({
         }
     }
 
+    var weight = xml.getElementsByTagName('weight');
+    if (weight.length > 0) {
+        var we = parseInt(weight[0].textContent);
+        this._trace.normal_style.weight = we;
+        this._trace.focus_style.weight = we+2;
+    }
+
     var parseElements = options.gpx_options.parseElements;
     if (parseElements.indexOf('route') > -1) {
       // routes are <rtept> tags inside <rte> sections

--- a/index.html
+++ b/index.html
@@ -347,7 +347,7 @@
                 <input id="color-checkbox" type="checkbox"> <label for="color-checkbox">Apply color to all traces</label><br>
                 <label for="opacity-slider">Opacity</label> <input type="range" min="0" max="1" step="0.01" id="opacity-slider" style="vertical-align: bottom"><br>
                 <input id="opacity-checkbox" type="checkbox"> <label for="opacity-checkbox">Apply opacity to all traces</label><br>
-                <label for="width-slider">Width</label> <input type="range" min="0" max="16" step="1" id="width-slider" style="vertical-align: bottom"><br>
+                <label for="width-slider">Width</label> <input type="range" min="1" max="10" step="1" id="width-slider" style="vertical-align: bottom"><br>
                 <input id="width-checkbox" type="checkbox"> <label for="width-checkbox">Apply width to all traces</label>
             </div>
             <div id="validate-color" class="panels custom-button normal-button">Ok</div>

--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
             <div class="panels-button" id="combine" title="Merge with another trace"><i class="fas fa-plus-circle custom-button"></i></div><br>
             <div class="panels-button" id="extract" title="Extract track segments"><i class="fas fa-list-ul custom-button"></i></div><br>
             <div class="panels-button" id="duplicate" title="Duplicate"><i class="fas fa-copy custom-button"></i></div><br>
-            <div class="panels-button" id="color" title="Change color and opacity"><i class="fas fa-palette custom-button"></i></div><br>
+            <div class="panels-button" id="color" title="Change color, opacity and width"><i class="fas fa-palette custom-button"></i></div><br>
             <div class="panels-button" id="add-wpt" title="Add waypoint"><i class="fas fa-map-marker-alt custom-button"></i></div><br>
             <div class="panels-button" id="reduce" title="Reduce number of track points"><i class="fas fa-compress-alt custom-button"></i></div><br>
             <div class="panels-button" id="zone-delete" title="Delete all inside/outside rectangle selection"><i class="fas fa-vector-square custom-button"></i></div><br>
@@ -346,7 +346,9 @@
                 <label for="color-picker">Pick a new color</label> <input type="color" id="color-picker" class="input-minimal" value="#ff0000" style="vertical-align: sub;"><br>
                 <input id="color-checkbox" type="checkbox"> <label for="color-checkbox">Apply color to all traces</label><br>
                 <label for="opacity-slider">Opacity</label> <input type="range" min="0" max="1" step="0.01" id="opacity-slider" style="vertical-align: bottom"><br>
-                <input id="opacity-checkbox" type="checkbox"> <label for="opacity-checkbox">Apply opacity to all traces</label>
+                <input id="opacity-checkbox" type="checkbox"> <label for="opacity-checkbox">Apply opacity to all traces</label><br>
+                <label for="width-slider">Width</label> <input type="range" min="0" max="16" step="1" id="width-slider" style="vertical-align: bottom"><br>
+                <input id="width-checkbox" type="checkbox"> <label for="width-checkbox">Apply width to all traces</label>
             </div>
             <div id="validate-color" class="panels custom-button normal-button">Ok</div>
             <div id="cancel-color" class="panels custom-button normal-button">Cancel</div>

--- a/js/buttons.js
+++ b/js/buttons.js
@@ -1403,7 +1403,7 @@ export default class Buttons {
             trace.focus_style.weight = weight+2;
             const hexOpacity = Math.round(opacity * 255).toString(16);
             if (buttons.color_checkbox.checked) total.same_color = true;
-            if (buttons.color_checkbox.checked || buttons.opacity_checkbox.checked) {
+            if (buttons.color_checkbox.checked || buttons.opacity_checkbox.checked || buttons.width_checkbox.checked) {
                 for (var i=0; i<total.traces.length; i++) {
                     if (buttons.color_checkbox.checked) {
                         total.traces[i].normal_style.color = color;

--- a/js/buttons.js
+++ b/js/buttons.js
@@ -104,6 +104,8 @@ export default class Buttons {
         this.color_checkbox = document.getElementById("color-checkbox");
         this.opacity_slider = document.getElementById("opacity-slider");
         this.opacity_checkbox = document.getElementById("opacity-checkbox");
+        this.width_slider = document.getElementById("width-slider");
+        this.width_checkbox = document.getElementById("width-checkbox");
         this.edit = document.getElementById("edit");
         this.validate = document.getElementById("validate");
         this.crop_container = document.getElementById("crop-container");
@@ -1382,6 +1384,7 @@ export default class Buttons {
 
             buttons.color_picker.value = trace.normal_style.color;
             buttons.opacity_slider.value = trace.normal_style.opacity;
+            buttons.width_slider.value = trace.normal_style.weight;
             if (buttons.window_open) buttons.window_open.hide();
             buttons.window_open = buttons.color_window;
             buttons.color_window.show();
@@ -1390,11 +1393,14 @@ export default class Buttons {
             const trace = total.traces[total.focusOn];
             const color = buttons.color_picker.value;
             const opacity = buttons.opacity_slider.value;
+            const weight = parseInt(buttons.width_slider.value);
             total.changeColor(trace.normal_style.color, color);
             trace.normal_style.color = color;
             trace.focus_style.color = color;
             trace.normal_style.opacity = opacity;
             trace.focus_style.opacity = opacity;
+            trace.normal_style.weight = weight;
+            trace.focus_style.weight = weight+2;
             const hexOpacity = Math.round(opacity * 255).toString(16);
             if (buttons.color_checkbox.checked) total.same_color = true;
             if (buttons.color_checkbox.checked || buttons.opacity_checkbox.checked) {
@@ -1407,6 +1413,10 @@ export default class Buttons {
                         total.traces[i].normal_style.opacity = opacity;
                         total.traces[i].focus_style.opacity = opacity;
                     }
+                    if (buttons.width_checkbox.checked) {
+                        total.traces[i].normal_style.weight = weight;
+                        total.traces[i].focus_style.weight = weight+2;
+                    }
                     total.traces[i].gpx.setStyle(total.traces[i].normal_style);
                     total.traces[i].tab.innerHTML = total.traces[i].name+'<div class="tab-color" style="background:'+total.traces[i].normal_style.color+hexOpacity+';">';
                     total.traces[i].set_color = true;
@@ -1418,6 +1428,10 @@ export default class Buttons {
                 if (buttons.opacity_checkbox.checked) {
                     total.normal_style.opacity = opacity;
                     total.focus_style.opacity = opacity;
+                }
+                if (buttons.width_checkbox.checked) {
+                    total.normal_style.weight = weight;
+                    total.focus_style.weight = weight;
                 }
             }
             trace.gpx.setStyle(trace.focus_style);

--- a/js/total.js
+++ b/js/total.js
@@ -439,6 +439,7 @@ export default class Total {
         <gpxx:Extensions>
         <color>`+this.traces[i].normal_style.color+`</color>
         <opacity>`+this.traces[i].normal_style.opacity+`</opacity>
+        <weight>`+this.traces[i].normal_style.weight+`</weight>
         </gpxx:Extensions>
         </gpxx:TrackExtension>
     </extensions>


### PR DESCRIPTION
This adds custom width/weight configuration option similarly how opacity is done right now.
![image](https://user-images.githubusercontent.com/1869097/139508520-b850eda5-ccb8-4755-ad30-8109405aa4a6.png)

I wasn't entirely sure on the naming since the CSS attribute is stroke-width, however the GPX and codebase called it weight (probably due to leaflet). Therefore I decided to call it width on UI side and weight in codebase (as it was before).

Checked the following:
- [x] Weight is applied to multiple lines at once if the checkbox is set 
- [X] Export of GPX saves the weight as GPX extension
- [X] Import of GPX correctly imports weight
- [X] Updated about page with width configuration information

It would be nice to check whether other editors in the wild aren't utilising width values between 1-100, however I don't have such test set.
