### PR TITLE
Suggest to  change the threshold for displaying POI overlay to a different zoom level

### DIFF
--- a/js/layers.js
+++ b/js/layers.js
@@ -190,7 +190,7 @@ for (var category in pointsOfInterest) {
     for (var poi of pointsOfInterest[category]) {
         pointsOfInterestLayers[category][poi.name] = new L.OverPassLayer({
             debug: false,
-            minZoom: 14,
+            minZoom: 11,
             endPoint: "https://overpass.kumi.systems/api/",
             query: "node({{bbox}})" + poi.query + ";out;",
             markerIcon: L.icon.glyph({


### PR DESCRIPTION
I am suggesting to change the threshold for displaying POI overlay in such a way that the points would show up at a wider zoom level (zoom 10 or 11 instead of 14).  The motivation being that when we are planning a route and searching for an hotel or a gas station we probably want to see a larger span of teritory to see what our options are.

Of course, this suggestion is made from the POV of someone in North America using motorized vehicles (which could be something conflicting with cyclists requirements).