### PR TITLE
Show time on point edit

### DIFF
--- a/js/trace.js
+++ b/js/trace.js
@@ -549,6 +549,7 @@ export default class Trace {
             if (trace._editMarkers.length == 1) return;
             insertTmpEditMarker();
             var content = '<div id="close-popup" class="custom-button" style="float: right;"><i class="fas fa-times"></i></div>';
+            content += '<div id="point-time">' + marker._pt.meta.time.toLocaleTimeString() + '</div>';
             if (marker != trace._editMarkers[0] && marker != trace._editMarkers[trace._editMarkers.length-1]) {
                 content += `<div id="split-waypoint" class="custom-button popup-action"><i class="fas fa-cut"></i> `+trace.buttons.split_text+`</div>
                             <div id="start-loop-waypoint" class="custom-button popup-action"><i class="fas fa-undo"></i> `+trace.buttons.start_loop_text+`</div>`;


### PR DESCRIPTION
Fixes #227. Certainly styling is up for debate here.

I looked into re-keying the height graph by time (rather than distance) or just showing the time of each point on hover. This chart is built using https://github.com/GIScience/Leaflet.Heightgraph which, unfortunately, is unmaintained and impossible to customize in this way.

<img width="919" alt="image" src="https://user-images.githubusercontent.com/98301/226206489-20254a6c-9954-47ad-890e-7c00a685d0a4.png">
