### PR TITLE
Increase pixel width of mapillary coverage

### DIFF
--- a/js/buttons.js
+++ b/js/buttons.js
@@ -634,7 +634,7 @@ export default class Buttons {
                             vectorTileLayerStyles: {
                                 sequence: {
                                     color: 'rgb(53, 175, 109)',
-                                    weight: 1,
+                                    weight: 6,
                                     opacity: 0.6
                                 },
                                 image: []
@@ -649,7 +649,7 @@ export default class Buttons {
                             vectorTileLayerStyles: {
                                 sequence: {
                                     color: 'rgb(53, 175, 109)',
-                                    weight: 1,
+                                    weight: 3.5,
                                     opacity: 0.6
                                 },
                                 image: []


### PR DESCRIPTION
I have been using mapillary with GPX studio quite a lot to identify areas of interest on my routes.   The default width is so thin that it is difficult to see what is covered and what not.

Note:  this proposed change is done from the perspective of someone in North America where roads and coverage might have less density than in Europe - so it might not make sense to all.

Nevertheless, I thought I would propose the changes and see.