### PR TITLE
Improve legibility of tabs

### DIFF
--- a/res/index.css
+++ b/res/index.css
@@ -756,8 +756,8 @@ html, body {
     border-radius: 4px 4px 0px 0px;
     margin-bottom: -5px;
     overflow-y: hidden;
-    font-size: 12px;
-    color: #777777;
+    font-size: 14px;
+    color: #454545;
     display:inline-block;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
@@ -777,6 +777,8 @@ html, body {
     -webkit-box-shadow: #BCBCBC 2px 0px 2px, #BCBCBC inset 0px 0px 0px;
     -moz-box-shadow: #BCBCBC 2px 0px 2px, #BCBCBC inset 0px 0px 0px;
     background-color: #fcfcfc;
+    color: #000000;
+    font-weight: bold;
 }
 .tab-color {
     position: inherit;


### PR DESCRIPTION
This change improves the legibility of the tabs by:

- increasing the font size slightly
- using a black color and bold type for the active tab
- increasing the width of the color bands

I made those changes while working on several GPX tracks and found myself confised about which tab was active vs not.

Before:

![image](https://github.com/gpxstudio/gpxstudio.github.io/assets/59520411/f7ee0ab2-10c4-4314-b6db-09e3b471e8f1)

After:

![image](https://github.com/gpxstudio/gpxstudio.github.io/assets/59520411/ee892371-9b51-4141-bb20-24a6c6eafb36)




