### PR TITLE
Squadrats integration

### DIFF
--- a/js/buttons.js
+++ b/js/buttons.js
@@ -548,6 +548,9 @@ export default class Buttons {
                             "Water" : layers.stravaHeatmapWater,
                             "Winter" : layers.stravaHeatmapWinter
                         },
+                        "Squadrats": {
+                            "All" : layers.squadrats
+                        },
                         "Waymarked Trails": {
                             "Hiking": layers.waymarkedTrailsHiking,
                             "Cycling": layers.waymarkedTrailsCycling,
@@ -586,6 +589,9 @@ export default class Buttons {
                             "Run" : true,
                             "Water" : true,
                             "Winter" : true
+                        },
+                        "Squadrats": {
+                            "All" : true
                         },
                         "Waymarked Trails": {
                             "Hiking": true,

--- a/js/layers.js
+++ b/js/layers.js
@@ -174,7 +174,22 @@ const layers = {
         maxNativeZoom: 14,
         maxZoom: MAX_ZOOM,
         attribution: '&copy; <a href="https://www.strava.com" target="_blank">Strava</a>'
-    })
+    }),
+    squadrats: L.geoJSON(JSON.parse(localStorage.getItem('squadrats')), {
+        style: (feature) => {
+            switch (feature.properties.name) {
+                case "squadrats": return {stroke: true, weight: 2, opacity: 1, fillOpacity: 0.3, color: '#ffedd9'};
+                case "yard": return {stroke: true, weight: 2, opacity: 1, fillOpacity: 0.3, color: '#fff'};
+                case "ubersquadrat": return {stroke: true, weight: 2, opacity: 1, fillOpacity: 0.0, color: '#f00'};
+                case "squadratinhos": return {stroke: true, weight: 2, opacity: 1, fillOpacity: 0.2, color: '#ffd5ab'};
+                case "yardinho": return {stroke: true, weight: 2, opacity: 1, fillOpacity: 0.2, color: '#ffc285'};
+                case "ubersquadratinho": return {stroke: true, weight: 2, opacity: 1, fillOpacity: 0.0, color: '#f00'};
+            }
+        },
+        maxNativeZoom: 18,
+        maxZoom: MAX_ZOOM,
+        attribution: '&copy; <a href="https://squadrats.com" target="_blank">Squadrats</a>'
+    }),
 };
 
 const overPassMinZoomOptions =  {


### PR DESCRIPTION
# What is Squadrats?

Let me pass the mic to the authors: https://squadrats.com/, the pitch is 30 seconds read.

For me, personally it's **a lot of fun** 🎉 .

# What's in the PR?

POC of displaying these squares on the map, as an overlay layer.

If you'd like to test it and don't have an account just copypaste this to `squadrats` key in localstorage, it would display a rectangle over Belgium:
```
{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"coordinates":[[[3.960807664215025,51.00447046929696],[3.960807664215025,50.64234162997474],[4.671143042915219,50.64234162997474],[4.671143042915219,51.00447046929696],[3.960807664215025,51.00447046929696]]],"type":"Polygon"}}]}
```
# How it's gonna work?

Squadrats exposes collected squares as a geojson file with a token in the URL (everyone who knows the link can get it, no verification of cookies takes place). POC expects the content to be in local storage, to make it work properly I'll need to add a bit of UI to copypaste the link.

# What I expect from you?

General review of the approach.

* Do you think it should work like that, or rather everything should be added to the app dynamically, and every line of code about this integration should go to something like `squadrats.js`?
* Does that have a chance to be included in the main branch, or you don't think such feature is a good idea, and if I'd like to use my only option is a fork?