### PR TITLE
Fix zoom levels for BGMountains

### DIFF
--- a/js/layers.js
+++ b/js/layers.js
@@ -101,8 +101,8 @@ const layers = {
         attribution: '&copy; <a href="https://www.maanmittauslaitos.fi/" target="_blank">Maanmittauslaitos</a>'
     }),
     bgMountains: L.tileLayer('https://bgmtile.kade.si/{z}/{x}/{y}.png', {
-        maxNativeZoom: 14,
-        maxZoom: 18,
+        maxNativeZoom: 18,
+        maxZoom: MAX_ZOOM,
         attribution: '<a href="http://mountain.bajhui.org/trac/wiki/BGMountains%20%D0%BB%D0%B5%D0%B3%D0%B5%D0%BD%D0%B4%D0%B0" target="_blank">BGM Legend</a> / <a href="https://cart.uni-plovdiv.net/" target="_blank">CART Lab</a>, <a href="http://www.bgmountains.org/" target="_blank">BGM team</a>, © <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">CC BY-SA 4.0</a>, <a href="http://bgmountains.org/en/maps/garmin-maps/category/9-bgmountains/" target="_blank">Garmin version</a>'
     }),
     usgs: L.tileLayer('https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}?blankTile=false', {


### PR DESCRIPTION
Details are not shown when zoom at max and the map looks blurry. Fixing zoom levels resolves the issue (similar to other maps.)